### PR TITLE
have sonar:sonar wait for quality gate

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -83,7 +83,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.sonar_token }}
           SONAR_HOST_URL: ${{ inputs.sonar_host_url }}
         run: |
-          ./mvnw clean install sonar:sonar
+          ./mvnw clean install sonar:sonar -Dsonar.qualitygate.wait=true
       
       - name: Cache github pages
         id: cache-github-pages


### PR DESCRIPTION
This will make it so the build fails if the quality gate fails.