### PR TITLE
use ntp flag for maven commands to limit output

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Get version
         id: get-version
         run: |
-          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          VERSION=$(./mvnw -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)
 
           if [[ ! $VERSION =~ "-SNAPSHOT" ]]; then
             echo "Current version is not a SNAPSHOT, please bump to the next SNAPSHOT to continue."
@@ -83,7 +83,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.sonar_token }}
           SONAR_HOST_URL: ${{ inputs.sonar_host_url }}
         run: |
-          ./mvnw clean install sonar:sonar
+          ./mvnw -ntp clean install sonar:sonar
       
       - name: Cache github pages
         id: cache-github-pages

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Maven SNAPSHOT
         run: |
-          ./mvnw -DskipTests=true clean deploy
+          ./mvnw -ntp -DskipTests=true clean deploy
       
       - name: Cache github pages
         id: cache-github-pages

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -65,21 +65,21 @@ jobs:
         run: |
           git config --global user.name 'Littera GitHub'
           git config --global user.email 'littera-github@litteraeducation.com'
-          ./mvnw --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
+          ./mvnw -ntp --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
 
       - name: Maven Release Minor
         if: ${{ inputs.version_increment_type == 'minor' }}
         run: |
           git config --global user.name 'Littera GitHub'
           git config --global user.email 'littera-github@litteraeducation.com'
-          ./mvnw --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
+          ./mvnw -ntp --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
 
       - name: Maven Release Major
         if: ${{ inputs.version_increment_type == 'major' }}
         run: |
           git config --global user.name 'Littera GitHub'
           git config --global user.email 'littera-github@litteraeducation.com'
-          ./mvnw --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.nextMajorVersion}.0.0-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
+          ./mvnw -ntp --batch-mode build-helper:parse-version release:prepare -DscmCommentPrefix="[skip ci][maven-release-plugin] " -DdevelopmentVersion=\${parsedVersion.nextMajorVersion}.0.0-SNAPSHOT -DreleaseVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -Darguments='-Dmaven.test.skip=true' release:perform
 
       - name: Cache github pages
         id: cache-github-pages


### PR DESCRIPTION
NTP (No Transfer Progress) will stop the maven output from stating uploading/downloading information. This will make the console output much cleaner. You can read more about it here:
https://maven.apache.org/docs/3.6.1/release-notes.html