### PR TITLE
replaced 'cluster_env' with 'env' in kubectl apply and rollout

### DIFF
--- a/.github/workflows/eks-deploy.yml
+++ b/.github/workflows/eks-deploy.yml
@@ -67,5 +67,5 @@ jobs:
           sed -i "s/NEW_RELIC_LICENSE_KEY_VALUE/${{ secrets.NEW_RELIC_LICENSE_KEY }}/g" config/${{ inputs.service_name }}/eks/eks-${{ inputs.env }}-deployment.yaml
           
           # Apply manifest and deploy
-          kubectl apply -f config/${{ inputs.service_name }}/eks/eks-${{ inputs.cluster_env }}-deployment.yaml
-          kubectl rollout restart deployment ${{ inputs.service_name }} -n littera-services-${{ inputs.cluster_env }}
+          kubectl apply -f config/${{ inputs.service_name }}/eks/eks-${{ inputs.env }}-deployment.yaml
+          kubectl rollout restart deployment ${{ inputs.service_name }} -n littera-services-${{ inputs.env }}


### PR DESCRIPTION
replaced 'cluster_env' with 'env' in kubectl apply and rollout; eks onfig files and namespaces are 'env' not 'cluster_env'