### PR TITLE
change cache hit to string, change output to comply with github actio…

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      version: ${{ steps.get-version.outputs.VERSION }}
+      version: ${{ steps.get-project-info.outputs.VERSION }}
 
     steps:
       - uses: actions/checkout@v2
@@ -62,10 +62,11 @@ jobs:
           active_profiles: '[ "github" ]'
           output_file: /home/runner/.m2/settings.xml
 
-      - name: Get version
-        id: get-version
+      - name: Get Project Info
+        id: get-project-info
         run: |
           VERSION=$(./mvnw -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)
+          NAME=$(./mvnw -ntp help:evaluate -Dexpression=project.name -q -DforceStdout)
 
           if [[ ! $VERSION =~ "-SNAPSHOT" ]]; then
             echo "Current version is not a SNAPSHOT, please bump to the next SNAPSHOT to continue."
@@ -76,7 +77,8 @@ jobs:
                   VERSION=$(echo $VERSION | cut -d- -f1)
           fi
 
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "NAME=$NAME" >> $GITHUB_OUTPUT
 
       - name: Maven Build and Sonar
         env:
@@ -90,4 +92,4 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target/docs
-          key: ${{ runner.os }}-${{ steps.get-version.outputs.VERSION }}-github-pages
+          key: ${{ steps.get-project-info.outputs.NAME }}-${{ steps.get-project-info.outputs.VERSION }}-github-pages

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -55,6 +55,12 @@ jobs:
           active_profiles: '[ "github" ]'
           output_file: /home/runner/.m2/settings.xml
 
+      - name: Get Project Info
+        id: get-project-info
+        run: |
+          NAME=$(./mvnw -ntp help:evaluate -Dexpression=project.name -q -DforceStdout)
+          echo "NAME=$NAME" >> $GITHUB_OUTPUT
+
       - name: Prep SSH
         uses: webfactory/ssh-agent@v0.5.4
         with:
@@ -86,11 +92,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target/docs
-          key: ${{ runner.os }}-${{ inputs.version }}-github-pages
+          key: ${{ steps.get-project-info.outputs.NAME }}-${{ inputs.version }}-github-pages
 
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@v4.3.3
-        if: steps.cache-github-pages.outputs.cache-hit == true
+        if: steps.cache-github-pages.outputs.cache-hit == 'true'
         with:
           branch: gh-pages
           target-folder: ${{ inputs.version }}


### PR DESCRIPTION
…ns new rules, change cache key since I learned it won't update a cache once made

https://littera.atlassian.net/browse/LDO-646

Skips it (the bug)
https://github.com/Littera-Education/littera-session-planner/actions/runs/3499009356/jobs/5860141512
![image](https://user-images.githubusercontent.com/99918016/202773005-0759b68a-d726-4662-b92c-3cf693244b44.png)


No longer skips it (the fix)
https://github.com/Littera-Education/littera-session-planner/actions/runs/3499143839/jobs/5860391599
![image](https://user-images.githubusercontent.com/99918016/202773076-e1b5dbf0-dd8e-4223-8eee-23d184b1afad.png)
