### PR TITLE
add U flag to update snapshots

### DIFF
--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Download Artifact
         run: |
-          ./mvnw dependency:copy -Dartifact=${{ inputs.GROUP_ID }}:${{ inputs.ARTIFACT_ID }}:${{ inputs.version }}:jar -DoutputDirectory=./target
+          ./mvnw dependency:copy -Dartifact=${{ inputs.GROUP_ID }}:${{ inputs.ARTIFACT_ID }}:${{ inputs.version }}:jar -DoutputDirectory=./target -U
       
       - name: Configure AWS Creds
         uses: aws-actions/configure-aws-credentials@v1-node16


### PR DESCRIPTION
Snapshots weren't properly being updated from Nexus (was using the local cache). The `-U` tells it to check with Nexus.

Testing Releases:
https://github.com/Littera-Education/littera-test-spring-boot-application/actions/runs/4046883190/jobs/6960330710
```
Downloaded from litteranexus: https://nexus.litteraeducation.com/repository/maven-public/com/litteraeducation/springboot/test-spring-boot-application/1.39.0/test-spring-boot-application-1.39.0.jar (81 MB at 62 MB/s)
[INFO] Copying test-spring-boot-application-1.39.0.jar to /home/runner/work/littera-test-spring-boot-application/littera-test-spring-boot-application/target/test-spring-boot-application-1.39.0.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```


Testing Snapshots:
https://github.com/Littera-Education/littera-test-spring-boot-application/actions/runs/4046770081/jobs/6960010327
```
Downloaded from litteranexus: https://nexus.litteraeducation.com/repository/maven-public/com/litteraeducation/springboot/test-spring-boot-application/1.39.0-SNAPSHOT/test-spring-boot-application-1.39.0-20230130.180610-4.jar (81 MB at 31 MB/s)
[INFO] Copying test-spring-boot-application-1.39.0-SNAPSHOT.jar to /home/runner/work/littera-test-spring-boot-application/littera-test-spring-boot-application/target/test-spring-boot-application-1.39.0-20230130.180610-4.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```