### PR TITLE
[LDO-1904] - Add export-vars Action

### DIFF
--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -68,7 +68,7 @@ jobs:
           repository: Littera-Education/littera-eks-config
           token: ${{ secrets.repo_token }}
           ref: ${{ inputs.eks_config_branch }}
-          path: config
+          path: eks-config
           fetch-depth: 0
       
       - name: export vars
@@ -76,26 +76,26 @@ jobs:
         run: |
           ### set target_config
           if [[ "${{ inputs.target_config}}" == "default" ]]; then
-            target_config=$(eval "jq -r '.${{ inputs.environment }}.default'" <<< config/env/EKS_JSON.json)
+            target_config=$(eval "jq -r '.${{ inputs.environment }}.default' eks-config/env/EKS_JSON.json")
           else
             target_config=${{ inputs.target_config }}
           fi
           echo "target_config=$target_config"
 
           ### export aws_account_id
-          account_name=$(eval "jq '.${{ inputs.environment }}.aws_account.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          account_name=$(eval "jq '.${{ inputs.environment }}.aws_account.\"$target_config\"' eks-config/env/EKS_JSON.json")
           echo "account_name=$account_name"
-          account_number=$(eval "jq -r '.aws_accounts[] | .account_name as \$account_name | select(.account_name == $account_name) | .account_number'" <<< config/env/EKS_JSON.json)
+          account_number=$(eval "jq -r '.aws_accounts[] | .account_name as \$account_name | select(.account_name == $account_name) | .account_number' eks-config/env/EKS_JSON.json")
           echo "aws_account_id=$account_number"
           echo "aws_account_id=$account_number" >> $GITHUB_OUTPUT
 
           ### export EKS cluster_name
-          cluster_name=$(eval "jq -r '.${{ inputs.environment }}.cluster.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          cluster_name=$(eval "jq -r '.${{ inputs.environment }}.cluster.\"$target_config\"' eks-config/env/EKS_JSON.json")
           echo "cluster_name=$cluster_name"
           echo "cluster_name=$cluster_name" >> $GITHUB_OUTPUT
 
           ### export kubctl_download_url
-          kubctl_download_url=$(eval "jq -r '.${{ inputs.environment }}.kubctl_download_url.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          kubctl_download_url=$(eval "jq -r '.${{ inputs.environment }}.kubctl_download_url.\"$target_config\"' eks-config/env/EKS_JSON.json")
           echo "kubctl_download_url=$kubctl_download_url"
           echo "kubctl_download_url=$kubctl_download_url" >> $GITHUB_OUTPUT
 
@@ -106,12 +106,12 @@ jobs:
           echo "service_name=${service_name}" >> $GITHUB_OUTPUT
 
           ### export iam_role
-          iam_role=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.\"$target_config\"'" <<< config/env/EKS_ROLES_JSON.json)
+          iam_role=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.\"$target_config\"' eks-config/env/EKS_ROLES_JSON.json")
           echo "iam_role=$iam_role"
           echo "iam_role=$iam_role" >> $GITHUB_OUTPUT
 
           ### export github_actions_deploy_timeout
-          github_actions_deploy_timeout=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.github_actions_deploy_timeout'" <<< config/env/EKS_REPO_JSON.json)
+          github_actions_deploy_timeout=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.github_actions_deploy_timeout' eks-config/env/EKS_REPO_JSON.json")
           echo "github_actions_deploy_timeout=$github_actions_deploy_timeout"
           echo "github_actions_deploy_timeout=$github_actions_deploy_timeout" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -9,8 +9,8 @@ on:
         default: "default"
       environment:
         description: Environment
-        required: true
         type: string
+        default: "dev"
       eks_config_branch:
         description: EKS Config Branch
         type: string

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -1,0 +1,120 @@
+name: Export Vars
+
+on:
+  workflow_call:
+    inputs:
+      target_config:
+        description: Target Config
+        type: string
+        default: "default"
+      environment:
+        description: Environment
+        required: true
+        type: string
+      eks_config_branch:
+        description: EKS Config Branch
+        type: string
+        default: "develop"
+
+    outputs:
+      cluster_name:
+        description: EKS Cluster Name
+        value: ${{ jobs.export-vars.outputs.cluster_name }}
+      kubctl_download_url:
+        description: kubectl Download URL
+        value: ${{ jobs.export-vars.outputs.kubctl_download_url }}
+      aws_account_id:
+        description: AWS Account ID
+        value: ${{ jobs.export-vars.outputs.aws_account_id }}
+      service_name:
+        description: Service Name
+        value: ${{ jobs.export-vars.outputs.service_name }}
+      iam_role:
+        description: IAM Role
+        value: ${{ jobs.export-vars.outputs.iam_role }}
+      environment:
+        description: Environment
+        value: ${{ jobs.export-vars.outputs.environment }}
+      github_actions_deploy_timeout:
+        description: Deployt Timeout
+        value: ${{ jobs.export-vars.outputs.github_actions_deploy_timeout }}
+
+    secrets:
+      repo_token:
+        required: true
+
+jobs:
+  export-vars:
+    name: Export Vars
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      cluster_name: ${{ steps.step_export_vars.outputs.cluster_name}}
+      kubctl_download_url: ${{ steps.step_export_vars.outputs.kubctl_download_url }}
+      aws_account_id: ${{ steps.step_export_vars.outputs.aws_account_id }}
+      service_name: ${{ steps.step_export_vars.outputs.service_name }}
+      iam_role: ${{ steps.step_export_vars.outputs.iam_role }}
+      environment: ${{ steps.step_export_vars.outputs.environment }}
+      github_actions_deploy_timeout: ${{ steps.step_export_vars.outputs.github_actions_deploy_timeout }}
+
+    steps:
+      - name: Checkout EKS Config
+        uses: actions/checkout@v3
+        with:
+          repository: Littera-Education/littera-eks-config
+          token: ${{ secrets.repo_token }}
+          ref: ${{ inputs.eks_config_branch }}
+          path: config
+          fetch-depth: 0
+      
+      - name: export vars
+        id: step_export_vars
+        run: |
+          ### set target_config
+          if [[ "${target_config}" == "default" ]]; then
+            target_config=$(eval "jq -r '.$environment.default'" <<< config/env/EKS_JSON.json)
+          else
+            target_config=$target_config
+          fi
+          echo "target_config=$target_config"
+
+          ### export aws_account_id
+          account_name=$(eval "jq '.$environment.aws_account.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          echo "account_name=$account_name"
+          account_number=$(eval "jq -r '.aws_accounts[] | .account_name as \$account_name | select(.account_name == $account_name) | .account_number'" <<< config/env/EKS_JSON.json)
+          echo "aws_account_id=$account_number"
+          echo "aws_account_id=$account_number" >> $GITHUB_OUTPUT
+
+          ### export EKS cluster_name
+          cluster_name=$(eval "jq -r '.$environment.cluster.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          echo "cluster_name=$cluster_name"
+          echo "cluster_name=$cluster_name" >> $GITHUB_OUTPUT
+
+          ### export kubctl_download_url
+          kubctl_download_url=$(eval "jq -r '.$environment.kubctl_download_url.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          echo "kubctl_download_url=$kubctl_download_url"
+          echo "kubctl_download_url=$kubctl_download_url" >> $GITHUB_OUTPUT
+
+          ### export service_name
+          service_name=(${repo//\// })
+          service_name=${service_name[1]}
+          echo "service_name=${service_name}"
+          echo "service_name=${service_name}" >> $GITHUB_OUTPUT
+
+          ### export iam_role
+          iam_role=$(eval "jq -r '.\"${service_name}\".$environment.\"$target_config\"'" <<< config/env/EKS_ROLES_JSON.json)
+          echo "iam_role=$iam_role"
+          echo "iam_role=$iam_role" >> $GITHUB_OUTPUT
+
+          ### export github_actions_deploy_timeout
+          github_actions_deploy_timeout=$(eval "jq -r '.\"${service_name}\".$environment.github_actions_deploy_timeout'" <<< config/env/EKS_REPO_JSON.json)
+          echo "github_actions_deploy_timeout=$github_actions_deploy_timeout"
+          echo "github_actions_deploy_timeout=$github_actions_deploy_timeout" >> $GITHUB_OUTPUT
+
+          ### export environment
+          echo "environment=$environment"
+          echo "environment=$environment" >> $GITHUB_OUTPUT

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -103,7 +103,8 @@ jobs:
           echo "kubctl_download_url=$kubctl_download_url" >> $GITHUB_OUTPUT
 
           ### export service_name
-          service_name=(${${{ inputs.service_repo }}//\// })
+          repo="${{ inputs.service_repo }}"
+          service_name=(${repo//\// })
           service_name=${service_name[1]}
           echo "service_name=${service_name}"
           echo "service_name=${service_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -42,6 +42,10 @@ on:
         description: Deployt Timeout
         value: ${{ jobs.export-vars.outputs.github_actions_deploy_timeout }}
 
+    secrets:
+      repo_token:
+        required: true
+
 jobs:
   export-vars:
     name: Export Vars
@@ -65,6 +69,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Littera-Education/littera-eks-config
+          token: ${{ secrets.repo_token }}
           ref: ${{ inputs.eks_config_branch }}
           path: eks-config
           fetch-depth: 0

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -42,10 +42,6 @@ on:
         description: Deployt Timeout
         value: ${{ jobs.export-vars.outputs.github_actions_deploy_timeout }}
 
-    secrets:
-      repo_token:
-        required: true
-
 jobs:
   export-vars:
     name: Export Vars
@@ -69,7 +65,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Littera-Education/littera-eks-config
-          token: ${{ secrets.repo_token }}
           ref: ${{ inputs.eks_config_branch }}
           path: eks-config
           fetch-depth: 0

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -3,6 +3,9 @@ name: Export Vars
 on:
   workflow_call:
     inputs:
+      service_repo:
+        description: Service Repo
+        type: string
       target_config:
         description: Target Config
         type: string
@@ -100,7 +103,7 @@ jobs:
           echo "kubctl_download_url=$kubctl_download_url" >> $GITHUB_OUTPUT
 
           ### export service_name
-          service_name=(${repo//\// })
+          service_name=(${${{ inputs.service_repo }}//\// })
           service_name=${service_name[1]}
           echo "service_name=${service_name}"
           echo "service_name=${service_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/export-vars.yml
+++ b/.github/workflows/export-vars.yml
@@ -75,27 +75,27 @@ jobs:
         id: step_export_vars
         run: |
           ### set target_config
-          if [[ "${target_config}" == "default" ]]; then
-            target_config=$(eval "jq -r '.$environment.default'" <<< config/env/EKS_JSON.json)
+          if [[ "${{ inputs.target_config}}" == "default" ]]; then
+            target_config=$(eval "jq -r '.${{ inputs.environment }}.default'" <<< config/env/EKS_JSON.json)
           else
-            target_config=$target_config
+            target_config=${{ inputs.target_config }}
           fi
           echo "target_config=$target_config"
 
           ### export aws_account_id
-          account_name=$(eval "jq '.$environment.aws_account.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          account_name=$(eval "jq '.${{ inputs.environment }}.aws_account.\"$target_config\"'" <<< config/env/EKS_JSON.json)
           echo "account_name=$account_name"
           account_number=$(eval "jq -r '.aws_accounts[] | .account_name as \$account_name | select(.account_name == $account_name) | .account_number'" <<< config/env/EKS_JSON.json)
           echo "aws_account_id=$account_number"
           echo "aws_account_id=$account_number" >> $GITHUB_OUTPUT
 
           ### export EKS cluster_name
-          cluster_name=$(eval "jq -r '.$environment.cluster.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          cluster_name=$(eval "jq -r '.${{ inputs.environment }}.cluster.\"$target_config\"'" <<< config/env/EKS_JSON.json)
           echo "cluster_name=$cluster_name"
           echo "cluster_name=$cluster_name" >> $GITHUB_OUTPUT
 
           ### export kubctl_download_url
-          kubctl_download_url=$(eval "jq -r '.$environment.kubctl_download_url.\"$target_config\"'" <<< config/env/EKS_JSON.json)
+          kubctl_download_url=$(eval "jq -r '.${{ inputs.environment }}.kubctl_download_url.\"$target_config\"'" <<< config/env/EKS_JSON.json)
           echo "kubctl_download_url=$kubctl_download_url"
           echo "kubctl_download_url=$kubctl_download_url" >> $GITHUB_OUTPUT
 
@@ -106,15 +106,15 @@ jobs:
           echo "service_name=${service_name}" >> $GITHUB_OUTPUT
 
           ### export iam_role
-          iam_role=$(eval "jq -r '.\"${service_name}\".$environment.\"$target_config\"'" <<< config/env/EKS_ROLES_JSON.json)
+          iam_role=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.\"$target_config\"'" <<< config/env/EKS_ROLES_JSON.json)
           echo "iam_role=$iam_role"
           echo "iam_role=$iam_role" >> $GITHUB_OUTPUT
 
           ### export github_actions_deploy_timeout
-          github_actions_deploy_timeout=$(eval "jq -r '.\"${service_name}\".$environment.github_actions_deploy_timeout'" <<< config/env/EKS_REPO_JSON.json)
+          github_actions_deploy_timeout=$(eval "jq -r '.\"${service_name}\".${{ inputs.environment }}.github_actions_deploy_timeout'" <<< config/env/EKS_REPO_JSON.json)
           echo "github_actions_deploy_timeout=$github_actions_deploy_timeout"
           echo "github_actions_deploy_timeout=$github_actions_deploy_timeout" >> $GITHUB_OUTPUT
 
           ### export environment
-          echo "environment=$environment"
-          echo "environment=$environment" >> $GITHUB_OUTPUT
+          echo "environment=${{ inputs.environment }}"
+          echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Context

Throughout all of our code repos we have manual entry of exporting vars from the GitHub Action secret variables. Whenever there are updates to `littera-eks-configs` we have to manually update the vars. This is unnecessary as we can simply checkout the repo using an action, in this case the new `export-vars` action.

This was successfully run on [littera-test-spring-application](https://github.com/Littera-Education/littera-test-spring-boot-application/actions/runs/5834248314/job/15823370304) using the [feature/export-vars-action](https://github.com/Littera-Education/littera-test-spring-boot-application/tree/feature/export-vars-action) branch

# Appendix

* [LDO-1904](https://littera.atlassian.net/browse/LDO-1904)

[LDO-1904]: https://littera.atlassian.net/browse/LDO-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ