### PR TITLE
LDO-1868 - Fix npm-test flow

### DIFF
--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,6 +1,10 @@
+# v8.2.0 (08/16/2023)
+* Fixed npm.test. Input local_runner was mistakenly put into secrets instead of inputs
+
 # v8.1.0 (08/16/2023)
 * Fixed create-test-image-v2.yml calling docker-build-and-push-image.yml
 
+# v8.0.0 (08/16/2023)
 * Added inputs.local_runner to all (required=false); defaults to 'self-hosted-runner-standard' for java, "ubuntu-latest" for node, vercel and serverless workflows.
 * Downloads software not pre-installed on the local runner for java workflows only
 

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -15,6 +15,10 @@ on:
       package_manager:
         type: string
         default: npm
+      local_runner:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
     secrets:
       nexus_username:
@@ -23,10 +27,6 @@ on:
         required: true
       sonar_token:
         required: true
-      local_runner:
-        required: false
-        type: string
-        default: "ubuntu-latest"
 
     outputs:
       version:


### PR DESCRIPTION
Input `local_runner` was mistakenly put into `secrets` instead of `inputs`