### PR TITLE
Set 'self-hosted-runner-standard' for node/vercel/serverless

### DIFF
--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,3 +1,6 @@
+# v8.3.0 (08/18/2023)
+* Set 'self-hosted-runner-standard' for node, vercel and serverless workflows.
+
 # v8.2.0 (08/16/2023)
 * Fixed npm.test. Input local_runner was mistakenly put into secrets instead of inputs
 

--- a/.github/workflows/npm-build-and-release.yml
+++ b/.github/workflows/npm-build-and-release.yml
@@ -24,7 +24,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:

--- a/.github/workflows/npm-lib-build-and-publish.yml
+++ b/.github/workflows/npm-lib-build-and-publish.yml
@@ -24,7 +24,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -18,7 +18,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:

--- a/.github/workflows/npm-ui-build-and-deploy.yml
+++ b/.github/workflows/npm-ui-build-and-deploy.yml
@@ -18,7 +18,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:
@@ -51,7 +51,7 @@ jobs:
 
   vercel_release:
     needs: [ npm_build_deploy ]
-    uses: Littera-Education/littera-github-actions/.github/workflows/vercel-deploy.yml@master
+    uses: ./.github/workflows/vercel-deploy.yml
     with:
       git_tag: ${{ github.ref_name }}
       nexus_host_domain: ${{ inputs.nexus_host_domain }}

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -15,7 +15,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:

--- a/.github/workflows/serverless-deploy.yml
+++ b/.github/workflows/serverless-deploy.yml
@@ -18,7 +18,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -21,7 +21,7 @@ on:
       local_runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "self-hosted-runner-standard"
 
     secrets:
       nexus_username:


### PR DESCRIPTION
Testing node/vercel/serverless builds/deploys showed no issues with using the self-hosted runner. Now let's set this to the default.