### PR TITLE
feat: ldo-2370 Add support for yarn berry.

### DIFF
--- a/.github/workflows/node-test-sharded.yml
+++ b/.github/workflows/node-test-sharded.yml
@@ -9,7 +9,7 @@ on:
         type: string
       node_version:
         type: number
-        default: 16
+        default: 18
 
     secrets:
       nexus_username:
@@ -38,16 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup .npmrc for pulling & publishing to Nexus
-        run: |
-          echo -e '\n' \
-          'registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n' \
-          '_auth=${{ secrets.nexus_npm_login }}\n' \
-          '//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n' \
-          'email=${{ secrets.nexus_username }}\n' \
-          'always-auth=true\n' \
-          >> .npmrc
-
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -55,6 +45,15 @@ jobs:
 
       - name: Install yarn
         run: npm install -g yarn
+
+      - name: Setup .npmrc for pulling & publishing to Nexus
+        run: |
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+          yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+          yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+          yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
 
       - name: Yarn Install Dependencies
         run: yarn install

--- a/.github/workflows/npm-build-and-release.yml
+++ b/.github/workflows/npm-build-and-release.yml
@@ -74,18 +74,27 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-          fi
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          fi
 
       - name: Install dependencies (with cache)
         if: ${{ inputs.custom_npm_install_command == 'skip' }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -57,19 +57,28 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
           fi
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
-          
       - name: Get Project Info
         id: get-project-info
         run: |

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -41,19 +41,28 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+          if [ ! "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ ! "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
           fi
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
-          
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ ! "${{ inputs.package_manager }}" == "berry" ]; 
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
             then
               yarn config set npmAlwaysAuth true
               yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
@@ -51,7 +51,7 @@ jobs:
               yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
             else
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ ! "${{ inputs.package_manager }}" == "yarn" ]; then
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
                 FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
               fi
 

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -58,18 +58,27 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-          fi
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          fi
 
       - name: Vercel Build
         env:

--- a/env/VERCEL.json
+++ b/env/VERCEL.json
@@ -14,8 +14,8 @@
     "littera-core-ui": {
         "local_runner":  "self-hosted-runner-standard",
         "testing_workflow": "sharded_test",
-        "package_manager": "yarn",
-        "node_version": "16"
+        "package_manager": "berry",
+        "node_version": "18"
     },
     "littera-goboard": {
         "local_runner":  "self-hosted-runner-standard",


### PR DESCRIPTION
Add support for yarn berry using `package_manager` property of `berry`. The main reason for this is so we can get over the Node 18 Upgrade Hurdle.

- Vercel, No longer supporting 16 on Feb 2024
- SonarCloud, No longer supporting 16 end of this Nov 2023