### PR TITLE
feat: ldo-2370 add support for yarn berry

### DIFF
--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,6 +1,6 @@
-# v8.13.0 (12/1/2023)
+# v8.13.0 (12/11/2023)
 * Add support for `berry` npm package manager, in order to migrate to node18. See: [LDO-2370](https://littera.atlassian.net/browse/LDO-2370)
-* 
+
 # v8.12.0 (12/05/2023)
 * `npm-build-and-release.yml` accomodates case when branch_name=develop-snapshot
 * `npm-get-project-info.yml` added. Returns version and artifact_id from package.json

--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,3 +1,6 @@
+# v8.12.0 (12/1/2023)
+* Add support for `berry` npm package manager, in order to migrate to node18. See: [LDO-2370](https://littera.atlassian.net/browse/LDO-2370)
+
 # v8.11.0 (11/21/2023)
 * Fixed `lcov-result-merger` upgrade in `node-test-sharded.yml`. (see: [LDO-2428](https://littera.atlassian.net/browse/LDO-2428)) 
 

--- a/.github/workflows/node-test-sharded.yml
+++ b/.github/workflows/node-test-sharded.yml
@@ -9,7 +9,7 @@ on:
         type: string
       node_version:
         type: number
-        default: 16
+        default: 18
 
     secrets:
       nexus_username:
@@ -38,16 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup .npmrc for pulling & publishing to Nexus
-        run: |
-          echo -e '\n' \
-          'registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n' \
-          '_auth=${{ secrets.nexus_npm_login }}\n' \
-          '//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n' \
-          'email=${{ secrets.nexus_username }}\n' \
-          'always-auth=true\n' \
-          >> .npmrc
-
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -55,6 +45,15 @@ jobs:
 
       - name: Install yarn
         run: npm install -g yarn
+
+      - name: Setup .npmrc for pulling & publishing to Nexus
+        run: |
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+          yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+          yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+          yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
 
       - name: Yarn Install Dependencies
         run: yarn install

--- a/.github/workflows/npm-build-and-release.yml
+++ b/.github/workflows/npm-build-and-release.yml
@@ -74,18 +74,27 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-          fi
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          fi
 
       - name: Install dependencies (with cache)
         if: ${{ inputs.custom_npm_install_command == 'skip' }}

--- a/.github/workflows/npm-build-and-release.yml
+++ b/.github/workflows/npm-build-and-release.yml
@@ -77,20 +77,23 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ "${{ inputs.package_manager }}" == "berry" ]; 
-            then
-              yarn config set npmAlwaysAuth true
-              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
-              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+          if [ "${{ inputs.package_manager }}" == "berry" ]; then
+            yarn config set npmAlwaysAuth true
+            yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+            yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
-            else
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+          elif [ "${{ inputs.package_manager }}" == "yarn" ]; then
+            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+            echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          elif [ "${{ inputs.package_manager }}" == "npm" ]; then
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
-                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-              fi
-
               echo -e "\n" \
                 "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
                 "$FULL_REPO_AUTH\n" \

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -57,19 +57,28 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
           fi
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
-          
       - name: Get Project Info
         id: get-project-info
         run: |

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -57,20 +57,23 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ "${{ inputs.package_manager }}" == "berry" ]; 
-            then
-              yarn config set npmAlwaysAuth true
-              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
-              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+          if [ "${{ inputs.package_manager }}" == "berry" ]; then
+            yarn config set npmAlwaysAuth true
+            yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+            yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
-            else
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+          elif [ "${{ inputs.package_manager }}" == "yarn" ]; then
+            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+            echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          elif [ "${{ inputs.package_manager }}" == "npm" ]; then
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
-                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-              fi
-
               echo -e "\n" \
                 "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
                 "$FULL_REPO_AUTH\n" \

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -41,19 +41,28 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+          if [ ! "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ ! "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
           fi
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
-          
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ ! "${{ inputs.package_manager }}" == "berry" ]; 
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
             then
               yarn config set npmAlwaysAuth true
               yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
@@ -51,7 +51,7 @@ jobs:
               yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
             else
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ ! "${{ inputs.package_manager }}" == "yarn" ]; then
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
                 FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
               fi
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -41,20 +41,23 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ "${{ inputs.package_manager }}" == "berry" ]; 
-            then
-              yarn config set npmAlwaysAuth true
-              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
-              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+          if [ "${{ inputs.package_manager }}" == "berry" ]; then
+            yarn config set npmAlwaysAuth true
+            yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+            yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
-            else
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+          elif [ "${{ inputs.package_manager }}" == "yarn" ]; then
+            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+            echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          elif [ "${{ inputs.package_manager }}" == "npm" ]; then
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
-                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-              fi
-
               echo -e "\n" \
                 "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
                 "$FULL_REPO_AUTH\n" \

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -58,18 +58,27 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-          if [ ! "${{ inputs.package_manager }}" == "npm" ]; then
-            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-          fi
+          if [ "${{ inputs.package_manager }}" == "berry" ]; 
+            then
+              yarn config set npmAlwaysAuth true
+              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-          echo -e "\n" \
-          "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
-          "$FULL_REPO_AUTH\n" \
-          "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
-          "email=${{ secrets.nexus_username }}\n" \
-          "always-auth=true\n" \
-          >> .npmrc
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+            else
+              FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
+              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
+                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+              fi
+
+              echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          fi
 
       - name: Vercel Build
         env:

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -58,20 +58,23 @@ jobs:
 
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
-          if [ "${{ inputs.package_manager }}" == "berry" ]; 
-            then
-              yarn config set npmAlwaysAuth true
-              yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
-              yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
+          if [ "${{ inputs.package_manager }}" == "berry" ]; then
+            yarn config set npmAlwaysAuth true
+            yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
+            yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public
 
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
-              yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
-            else
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAuthIdent' ${{ secrets.nexus_npm_login }}
+            yarn config set 'npmRegistries["//${{ inputs.nexus_host_domain }}/repository/npm-local/"].npmAlwaysAuth' true
+          elif [ "${{ inputs.package_manager }}" == "yarn" ]; then
+            FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
+            echo -e "\n" \
+                "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
+                "$FULL_REPO_AUTH\n" \
+                "//${{ inputs.nexus_host_domain }}/repository/npm-local:_auth=${{ secrets.nexus_npm_login }}\n" \
+                "email=${{ secrets.nexus_username }}\n" \
+                "always-auth=true\n" \ >> .npmrc
+          elif [ "${{ inputs.package_manager }}" == "npm" ]; then
               FULL_REPO_AUTH="//${{ inputs.nexus_host_domain }}/repository/:_auth=${{ secrets.nexus_npm_login }}"
-              if [ "${{ inputs.package_manager }}" == "yarn" ]; then
-                FULL_REPO_AUTH="_auth=${{ secrets.nexus_npm_login }}"
-              fi
-
               echo -e "\n" \
                 "registry=https://${{ inputs.nexus_host_domain }}/repository/npm-public\n" \
                 "$FULL_REPO_AUTH\n" \

--- a/env/VERCEL.json
+++ b/env/VERCEL.json
@@ -14,8 +14,8 @@
     "littera-core-ui": {
         "local_runner":  "self-hosted-runner-standard",
         "testing_workflow": "sharded_test",
-        "package_manager": "yarn",
-        "node_version": "16"
+        "package_manager": "berry",
+        "node_version": "18"
     },
     "littera-goboard": {
         "local_runner":  "self-hosted-runner-standard",


### PR DESCRIPTION
Resolves, https://littera.atlassian.net/browse/LDO-2370

1. New `berry` property for `package_manager`.
2. Swap `yarn` to `berry` in core-ui.
3. Upgrade to node 18 for core-ui.

Things I need to do:
- Finishing up testing workflow:
   - berry (using core-ui)
      - node-test-sharded 🟢 
      - pr-title-lint 🟢 
      - vercel-deploy 🔴  see below.
      - npm-test 🔴  (not used in core-ui)
      - `I still need to test this in main merge workflow`(we probably need to make a new repo for this).
   - yarn (using toolkit)
      - node-test-sharded 🔴 (not used in toolkit)
      - pr-title-lint 🟢 
      - vercel-deploy (need to test this in main)
      - npm
   - npm (using littera-ui-test-node-application)
     -  [npm-build-test-and-release](https://github.com/Littera-Education/littera-test-ui-application/actions/runs/6893599448) 🟢 
     -  npm-test 🟢 
     -  pr-title-lint 🟢 
     -  vercel-deploy 🟢 
     - node-test-sharded 🔴  (not used)
- Prep Yarn Berry PR to be ready to merge (littera-core-ui)
- Coordinate the move to `yarn berry` after this merge.