### PR TITLE
fix: LDO-2428 fix failing `sharded_test` job in core-ui.

### DIFF
--- a/.github/workflows/node-test-sharded.yml
+++ b/.github/workflows/node-test-sharded.yml
@@ -94,7 +94,7 @@ jobs:
           path: coverage
 
       - name: Merge Code Coverage
-        run: npx lcov-result-merger 'coverage/lcov_*.info' 'coverage/lcov.info'
+        run: npx lcov-result-merger 'coverage/lcov_*.info' 'coverage/lcov.info' --legacy-temp-file
 
         # https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner/
       - name: Run Sonar Analysis


### PR DESCRIPTION
See for more info: https://littera.atlassian.net/browse/LDO-2428,

a breaking change `lcov-result-merger` release 5.0 has occurred we need to add `--legacy-temp-file`.

Sample test run, as you can see the `report-coverage` now passes:
https://github.com/Littera-Education/littera-core-ui/actions/runs/6949313119