### PR TITLE
fix: missing `yarn` to configure

### DIFF
--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,3 +1,6 @@
+# v8.13.1 (12/11/2023)
+* Upon testing `core-ui`, the `yarn` package manager is missing to configure the `.yarnrc.yml`.
+
 # v8.13.0 (12/11/2023)
 * Add support for `berry` npm package manager, in order to migrate to node18. See: [LDO-2370](https://littera.atlassian.net/browse/LDO-2370)
 

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Setup .npmrc for pulling & publishing to Nexus
         run: |
           if [ "${{ inputs.package_manager }}" == "berry" ]; then
+            npm install -g yarn
             yarn config set npmAlwaysAuth true
             yarn config set npmAuthIdent ${{ secrets.nexus_npm_login }}
             yarn config set npmRegistryServer https://${{ inputs.nexus_host_domain }}/repository/npm-public


### PR DESCRIPTION
We are missing the `yarn` cli to configure the `.yarnc.yml` file.