### PR TITLE
test: Core-UI Rollback

### DIFF
--- a/.github/workflows/changelog.md
+++ b/.github/workflows/changelog.md
@@ -1,3 +1,6 @@
+# v8.13.1 (12/13/2023)
+* Reverting back to `yarn` briefly for core-ui rollback testing.
+
 # v8.13.0 (12/11/2023)
 * Add support for `berry` npm package manager, in order to migrate to node18. See: [LDO-2370](https://littera.atlassian.net/browse/LDO-2370)
 

--- a/env/VERCEL.json
+++ b/env/VERCEL.json
@@ -14,8 +14,8 @@
     "littera-core-ui": {
         "local_runner":  "self-hosted-runner-standard",
         "testing_workflow": "sharded_test",
-        "package_manager": "berry",
-        "node_version": "18"
+        "package_manager": "yarn",
+        "node_version": "16"
     },
     "littera-goboard": {
         "local_runner":  "self-hosted-runner-standard",


### PR DESCRIPTION
Reverting to `yarn` for core-ui rollback testing.